### PR TITLE
5.0.1対応。インストール先にUbuntu(Debian)を追加

### DIFF
--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -1,7 +1,7 @@
 case node['platform_family']
-when 'rhel'
-  default['pentaho']['biserver']['binaryname'] = "biserver-ce-4.8.0-stable.tar.gz"
-  default['pentaho']['biserver']['url'] = "http://downloads.sourceforge.net/project/pentaho/Business%20Intelligence%20Server/4.8.0-stable/biserver-ce-4.8.0-stable.tar.gz"
+when 'rhel', 'debian'
+  default['pentaho']['biserver']['binaryname'] = "biserver-ce-5.0.1-stable.zip"
+  default['pentaho']['biserver']['url'] = "http://downloads.sourceforge.net/project/pentaho/Business%20Intelligence%20Server/5.0.1-stable/biserver-ce-5.0.1-stable.zip?use_mirror=softlayer-dal"
 
 else
   default['pentaho']['biserver']['url'] = nil

--- a/templates/default/pentahobictl.erb
+++ b/templates/default/pentahobictl.erb
@@ -8,21 +8,21 @@
 # X-Interactive:     true
 # Short-Description: Pentaho BI Platform
 ### END INIT INFO
-export JAVA_HOME="/usr/java/latest"
-export JRE_HOME="/usr/java/latest/jre"
-export PANTAHO_HOME="/usr/local/pentaho"
+<% if node['platform_family'] == 'rhel' %>
+  export JAVA_HOME="/usr/java/latest"
+  export JRE_HOME="/usr/java/latest/jre"
+<% end %>
+export PENTAHO_HOME="/usr/local/pentaho"
 
 start(){
   echo "start pentaho biserver"
-  cd $PANTAHO_HOME/biserver-ce; ./start-pentaho.sh > /tmp/pentaho.out 2>&1
-  cd $PANTAHO_HOME/administration-console; ./start-pac.sh > /tmp/pentahoadm.out 2>&1 &
+  cd $PENTAHO_HOME/biserver-ce; ./start-pentaho.sh > /tmp/pentaho.out 2>&1
   echo "ok"
 }
 
 stop(){
   echo "stop pentaho biserver"
-  cd $PANTAHO_HOME/biserver-ce; ./stop-pentaho.sh > /tmp/pentaho.out 2>&1
-  cd $PANTAHO_HOME/administration-console; ./stop-pac.sh > /tmp/pentahoadm.out 2>&1
+  cd $PENTAHO_HOME/biserver-ce; ./stop-pentaho.sh > /tmp/pentaho.out 2>&1
   echo "ok"
 }
 


### PR DESCRIPTION
Business Intelligence Serverの5.0.1-stableに対応しました。

また、Ubuntuでもインストールができるように修正しました。
UbuntuではOracle JDKとOpenJDKの両方で動作を確認しています。
## 動作確認した環境

| OS | Java |
| --- | --- |
| CentOS 6.5 | 1.7.0_67 |
| Ubuntu 14.04 | 1.7.0_67 |
### Ubuntuの動作確認で使用したOpenJDKのインストール手順

``` bash
sudo apt-get update
sudo apt-get install openjdk-7-jre-headless
```
### Ubuntuの動作確認で使用したOracle JDKのインストール手順

``` bash
sudo add-apt-repository ppa:webupd8team/java
sudo apt-get update
sudo apt-get install oracle-java7-installer
```
